### PR TITLE
Update FirewallTests-FiskalyCloud2.csv

### DIFF
--- a/fw-script/FirewallTests-FiskalyCloud2.csv
+++ b/fw-script/FirewallTests-FiskalyCloud2.csv
@@ -2,4 +2,4 @@ Url,Code,Purpose
 https://helipad.fiskaltrust.cloud/version,200,ft cashbox download & upload receipt data
 https://packages.fiskaltrust.cloud/version,200,ft download packages
 https://dc.services.visualstudio.com/,404,ft error reporting
-https://kassensichv-middleware.fiskaly.com/api/v2,401,fiskaly cloud TSE 2
+https://kassensichv-middleware.fiskaly.com/api/v2,200,fiskaly cloud TSE 2


### PR DESCRIPTION
Previously it wasn't possible to access "kassensichv-middleware.fiskaly.com/api/v2" and the way to check if the site is reachable was to wait for Code 401. But now the site is accessible  and the response Code should be 200. The Code 401 isn't returned anymore, so the Script always fails for Fiskaly V2. With Code 200 it works like it was supposed to.