### PR TITLE
Changed package name for fiskaly TSE

### DIFF
--- a/middleware/README.md
+++ b/middleware/README.md
@@ -1010,7 +1010,7 @@ Indicates the type of SCU you'd want to reference to. Possible values for `type`
 * **cryptovision**
 * **dieboldnixdorf**
 * **epson**
-* **FiskalyCertified**
+* **fiskalycertified**
 * **swissbit**
 * **swissbitcloud**
 

--- a/middleware/README.md
+++ b/middleware/README.md
@@ -932,7 +932,7 @@ Folgende Packages stehen aktuell für SCUs zur Verfügung:
 | `fiskaltrust.Middleware.SCU.DE.CryptoVision`   | This package enables communication with a Cryptovision TSE.    |
 | `fiskaltrust.Middleware.SCU.DE.DieboldNixdorf` | This package enables communication with a Diebold Nixdorf TSE. |
 | `fiskaltrust.Middleware.SCU.DE.Epson`          | This package enables communication with an Epson TSE.          |
-| `fiskaltrust.Middleware.SCU.DE.fiskaly`        | This package enables communication with a fiskaly Cloud-TSE.         |
+| `fiskaltrust.Middleware.SCU.DE.FiskalyCertified`        | This package enables communication with a certified fiskaly Cloud-TSE.         |
 | `fiskaltrust.Middleware.SCU.DE.Swissbit`       | This package enables communication with a Swissbit TSE.        |
 
 The following key-value pairs are used in the **`Configuration`** object of a **SCU** depending on the manufacturer of the TSE:
@@ -1010,7 +1010,7 @@ Indicates the type of SCU you'd want to reference to. Possible values for `type`
 * **cryptovision**
 * **dieboldnixdorf**
 * **epson**
-* **fiskalycertified**
+* **FiskalyCertified**
 * **swissbit**
 * **swissbitcloud**
 


### PR DESCRIPTION
The documentation still contained the package name for the fiskaly V1 (fiskaltrust.Middleware.SCU.DE.fiskaly). I updated it to the correct package name for the fiskaly V2 TSE (fiskaltrust.Middleware.SCU.DE.FiskalyCertified)