### PR TITLE
Corrected moment of SwissbitCloud-TSE (FCC) initialization

### DIFF
--- a/i18n/de/shop/swissbit-cloud-special.md
+++ b/i18n/de/shop/swissbit-cloud-special.md
@@ -6,8 +6,8 @@ Die Swissbit Cloud TSE hat gegenüber anderen fiskaltrust.Middleware Konfigurati
 3.	Zusätzliche Firewall Erfordernisse für die notwendige Internetverbindung
 
 ##### 1. Die Swissbit Cloud TSE wird mit dem Computer, auf dem sie läuft, fix verbunden (gepaired).
-* Die Swissbit Cloud TSE wird bei der Initialisierung fix mit dem Computer verbunden, auf dem diese durchgeführt wird. Nach der ersten Kommunikation mit den Swissbit Cloud Servern kann diese nur mehr auf genau diesem Computer ausgeführt werden. <br />Bei der fiskaltrust.Middleware wird die Initialisierung mit dem **Startbeleg oder Initial-operation receipt** durchgeführt.
-* Daher kann die fiskaltrust.Middleware in Verbindung mit der Swissbit Cloud TSE auch nicht auf anderen Geräten testhalber ausgeführt werden. Die Installation ist nur einmalig möglich. Wenn etwas nicht nach Ihrem Wunsch eingerichtet und ein Initial-operation receipt versandt wird, muss die Swissbit Cloud TSE erneut erworben werden.
+* Die Swissbit Cloud TSE wird bei der Initialisierung fix mit dem Computer verbunden, auf dem diese durchgeführt wird. Nach der ersten Kommunikation mit den Swissbit Cloud Servern kann diese nur mehr auf genau diesem Computer ausgeführt werden. <br />Bei der fiskaltrust.Middleware wird die Initialisierung der SwissbitCloud (Fiscal-Cloud-Connector) mit dem ersten Start der fiskaltrust.Middleware durchgeführt.
+* Daher kann die fiskaltrust.Middleware in Verbindung mit der Swissbit Cloud TSE auch nicht auf anderen Geräten testhalber ausgeführt werden. Die Installation ist nur einmalig möglich. Wenn etwas nicht nach Ihrem Wunsch eingerichtet und bereits die fiskaltrust.Middleware erstmalig gestartet wurde, muss die Swissbit Cloud TSE erneut erworben werden.
 
 ##### 2. Einschränkungen des Produktes bei Einzelkauf
 * Bei Kauf einer Swissbit Cloud TSE als Einzelprodukt (nicht im Rahmen eines fiskaltrust.Sorglos Pakets) ist die Verwendung auf eine einzelne Queue eingeschränkt. Details entnehmen Sie bitte der Produktbeschreibung im [Download-Bereich vom fiskaltrust.Portal](https://portal.fiskaltrust.de/AccountProfile/Download). 


### PR DESCRIPTION
The FCC is already initialized with the first start of the middleware and not just with the initial-operation-receipt. With the old version of this document it seemed like the SwissbitCloud-TSE can be installed on other devices as long as no initial-operation-receipt was sent. The english version seems correct in that matter.