### PR TITLE
unify admonitions in documentation

### DIFF
--- a/getting-started/operator-onboarding/surrogating.md
+++ b/getting-started/operator-onboarding/surrogating.md
@@ -68,7 +68,7 @@ We use the example of checking the master data of a PosOperator to describe Surr
 |![Number 6](images/Numbers/circle-6o.png) |Choose `Outlets` to check these for completeness and correctness. |
 |  |Choose `Switch to your own account` to get back to your account and check other accounts of other PosOperators. |
 
-:::attention
+:::caution No access to employee data for PosDealer
 
 Please note that as a PosDealer, you cannot manage the data of employees in the fiskaltrust.Portal if you switch to a PosOperator account due to data privacy reasons.
 

--- a/getting-started/registration.md
+++ b/getting-started/registration.md
@@ -207,7 +207,7 @@ In the future, all users will use the login listed [above](registration.md#count
 
 The process described in this section for adding accounts for employees to your account (`Company` / `Employees` / `+Add`) also applies to adding accounts for employees to PosOperators. Please note that as a PosDealer, you cannot manage these data if you switch to a PosOperator account.
 
-:::attention
+:::caution No access to employee data for PosDealer
 
 Please note that as a PosDealer, you cannot manage the data of employees in the fiskaltrust.Portal if you switch to a PosOperator account due to data privacy reasons.
 


### PR DESCRIPTION
{Summary of the changes}

we had two admonitions with :::attention in the documentation, these were not displayed in a graphic manner. 
Changed that to :::caution, which is displayed with yellow background and an exclamation mark - symbol

Fixes #{issue number}
unplanned work