### PR TITLE
False Descriptions _parameters.mdx

### DIFF
--- a/_markets/de/technical-operations/rollout-automation/api-templating/_parameters.mdx
+++ b/_markets/de/technical-operations/rollout-automation/api-templating/_parameters.mdx
@@ -4,5 +4,5 @@ Requests for German CashBoxes only make use of the standard queue parameters.
 
 | Parameter                        | Description                                            |
 | -------------------------------- | ------------------------------------------------------ |
-| `CommissioningDate` (`queue{0-n}_commissioningdate`) | The date of purchase of the cash register or the start date of the cash register leasing period. The value is required for the notifications to the government but also can be added on a later date via the portal. Format: DD-MM-YYYY |
-| `PurchaseDate` (`queue{0-n}_purchasedate`)           | The date when you first used the cash register. The value is required for the notifications to the government but also can be added on a later date via the portal. Format: DD-MM-YYYY |
+| `PurchaseDate` (`queue{0-n}_purchasedate`)           | The date of purchase of the cash register or the start date of the cash register leasing period. The value is required for the notifications to the government but also can be added on a later date via the portal. Format: DD-MM-YYYY |
+| `CommissioningDate` (`queue{0-n}_commissioningdate`) | The date when you first used the cash register. The value is required for the notifications to the government but also can be added on a later date via the portal. Format: DD-MM-YYYY |


### PR DESCRIPTION
Purchase Date and Commissioning Date had the wrong descriptions. Switched them to the corresponding descriptions, so the make sense.

<!-- Thank you for submitting a pull request to our repo! -->

<!-- If this is your first PR to one of fiskaltrust's repos, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x ] You've read the [Contributor Guide](https://github.com/fiskaltrust/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/fiskaltrust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

{Summary of the changes}

## Description

Switched descriptions for the parameters, because the don´t match to another.

Fixes #{issue number}
